### PR TITLE
Add code of conduct transparency log

### DIFF
--- a/transparency-log.md
+++ b/transparency-log.md
@@ -15,7 +15,7 @@ the social standards expressed in the Code of Conduct.
 
 A public record allows the community to monitor the enforcement of the Code of
 Conduct and propose changes to the reporting and enforcement process if
-necessary.
+necessary. This log is updated once every six months. 
 
 ## Code of Conduct Reports and Responses
 

--- a/transparency-log.md
+++ b/transparency-log.md
@@ -1,0 +1,51 @@
+# US-RSE Code of Conduct Transparency Log
+
+The US-RSE expects everyone who participates in the community will honor our
+[Code of Conduct](https://us-rse.org/about/code-of-conduct/). This includes
+anyone participating in any US-RSE-related activities, anyone claiming
+affiliation with the US-RSE, and especially anyone representing the US-RSE
+Association in any role (including as a volunteer or speaker).
+
+This log serves to inform the US-RSE community about all responses to code of
+conduct reports in a public, aggregated, and anonymized form. We believe that a
+community must be able to see that a Code of Conduct is enforced in order for it
+to be effective. Without a visible process potential community members may not
+feel comfortable joining. A visible log can also help the community establish
+the social standards expressed in the code of conduct.
+
+A public record allows the community to monitor the enforcement of the Code of
+Conduct and propose changes to the reporting and enforcement process if
+necessary.
+
+## Code of Conduct Reports and Responses
+
+Updated as of June 30, 2022
+
+### May 9, 2022
+
+The contact@us-rse.org address received two reports of potential code of conduct
+violations from two US-RSE members. The reports were in regard to a post and
+subsequent comments made in a public US-RSE Slack channel that were perceived to
+have a hostile and antagonistic tone in a context that devalued the efforts of
+other members of the US-RSE community. The CoC review concluded that the
+language was negatively impactful and inconsistent with the CoC goals of
+maintaining a “welcoming, friendly community for all”, regardless of intent. A
+subgroup of the Steering Committee examined the CoC complaint. The group decided
+that privately communicating the nature of the complaint to the reported person
+was the appropriate action. It was decided that no further action was necessary.
+
+### January 7, 2021
+
+A message was sent to contact@us-rse.org to report an incident in a 1:1
+interaction in a US-RSE slack DM, with a request to keep the matter private.  A
+response was sent to the reporter that the code of conduct review group could
+not determine a responsive action that would maintain confidentiality, but that
+a general reminder about the Code of Conduct would be posted to members on Slack
+and in the newsletter.
+
+### September/October 2020
+
+In the process of verifying membership via email in September/October 2020, the
+leadership@us-rse.org account received threatening emails. This email address
+that sent the threatening emails was removed from all US-RSE lists and
+membership.

--- a/transparency-log.md
+++ b/transparency-log.md
@@ -19,7 +19,7 @@ necessary.
 
 ## Code of Conduct Reports and Responses
 
-Updated as of June 30, 2022
+Updated as of June 30, 2022. Reports listed in reverse chronological order.
 
 ### May 9, 2022
 

--- a/transparency-log.md
+++ b/transparency-log.md
@@ -6,12 +6,12 @@ anyone participating in any US-RSE-related activities, anyone claiming
 affiliation with the US-RSE, and especially anyone representing the US-RSE
 Association in any role (including as a volunteer or speaker).
 
-This log serves to inform the US-RSE community about all responses to code of
-conduct reports in a public, aggregated, and anonymized form. We believe that a
+This log serves to inform the US-RSE community about all responses to Code of
+Conduct reports in a public, aggregated, and anonymized form. We believe that a
 community must be able to see that a Code of Conduct is enforced in order for it
-to be effective. Without a visible process potential community members may not
+to be effective. Without a visible process, potential community members may not
 feel comfortable joining. A visible log can also help the community establish
-the social standards expressed in the code of conduct.
+the social standards expressed in the Code of Conduct.
 
 A public record allows the community to monitor the enforcement of the Code of
 Conduct and propose changes to the reporting and enforcement process if
@@ -37,7 +37,7 @@ was the appropriate action. It was decided that no further action was necessary.
 ### January 7, 2021
 
 A message was sent to contact@us-rse.org to report an incident in a 1:1
-interaction in a US-RSE slack DM, with a request to keep the matter private.  A
+interaction in a US-RSE Slack DM, with a request to keep the matter private.  A
 response was sent to the reporter that the code of conduct review group could
 not determine a responsive action that would maintain confidentiality, but that
 a general reminder about the Code of Conduct would be posted to members on Slack


### PR DESCRIPTION
This is a PR to add the Code of Conduct transparency log to the US-RSE documents repository.

As [discussed in the #wg-coc-moderation channel](https://usrse.slack.com/archives/C03GSRV3GHL/p1660184134916219), we plan to:

1. Publish the current version of the log here (this PR).
2. Publish a list of "maintained documents" on the [About/Governance](https://us-rse.org/about/governance/) page that will include the [Code of Conduct](https://us-rse.org/about/code-of-conduct/) and the Transparency Log
3. Add language to the Governance document stating that we will publish an update to the the log every six months, even if the update is simply "no new reports".