### PR TITLE
Semi-Annual (7-2023) Update of Transparency Log

### DIFF
--- a/transparency-log.md
+++ b/transparency-log.md
@@ -19,7 +19,15 @@ necessary. This log is updated once every six months.
 
 ## Code of Conduct Reports and Responses
 
-Updated as of January 27, 2023. Reports listed in reverse chronological order.
+Updated as of July 21, 2023. Reports listed in reverse chronological order.
+
+### February 24, 2023
+
+The contact@us-rse.org address received a report of a single individual's potential professional misconduct and academic dishonesty in violation of the Code of Conduct. 
+A request from the Code of Conduct response group to the reported individual went unanswered.
+The subsequent CoC review and investigation concluded that the reported individual’s actions were unethical and unprofessional and therefore violated the Code of Conduct. 
+The reported individual’s membership in US-RSE was suspended for 2 years during which time the individual may not participate in any US-RSE events or communication, in person, virtually, or asynchronously.
+
 
 ### November 7, 2022
 


### PR DESCRIPTION
This adds the only entry for the CoC Transparency Log for the time period of January 2023 - June 2023. 